### PR TITLE
chore: move dev deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "Parse a string containing environment variables to a key/value object",
   "main": "index.js",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "standard": "^14.3.4",
     "tape": "^5.0.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "standard && node test.js"
   },


### PR DESCRIPTION
Closes: #1

---

@watson The main motivation for this is a breakage in attempting to run eslint in https://github.com/open-telemetry/opentelemetry-js-contrib as somewhat described in [this comment](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1694#issuecomment-1730332161). That repo installs eslint at the top-level for linting. It is a monorepo with packages in subdirs. Some of the package subdirs have a dependency on test-all-versions@5, which deps on this package. Because this package installs eslint@6, attempts to lint in those subdirs accidentally get this eslint@6 and linting breaks -- hitting an incompatibility error between various eslint-related packages (https://github.com/prettier/eslint-plugin-prettier/issues/434).

The easiest fix is to:
- merge this
- release `parse-env-string@1.0.1`

The ` "parse-env-string": "^1.0.0",` range in test-all-versions@5 will then get the fixed version. Thanks.